### PR TITLE
fix(milestones): switch inline style for progress bar to class for CSP

### DIFF
--- a/_data/milestones.json
+++ b/_data/milestones.json
@@ -6,7 +6,8 @@
     "description": "This release is designed to take care of all outstanding bugs that exist in jQuery. It will, essentially, serve as a 'feature complete' version of the code that can be used to build later versions off of.",
     "total": 104,
     "closed": 104,
-    "percent": 100
+    "percent": 100,
+    "id": "1-0"
   },
   {
     "name": "1.1a",
@@ -15,7 +16,8 @@
     "description": "This release is set to make some minor API changes to the outstanding 1.0 release (in addition to the various post-1.0 bug fix releases).",
     "total": 54,
     "closed": 54,
-    "percent": 100
+    "percent": 100,
+    "id": "1-1a"
   },
   {
     "name": "1.1",
@@ -24,7 +26,8 @@
     "description": "",
     "total": 51,
     "closed": 51,
-    "percent": 100
+    "percent": 100,
+    "id": "1-1"
   },
   {
     "name": "1.1.2",
@@ -33,7 +36,8 @@
     "description": "",
     "total": 13,
     "closed": 13,
-    "percent": 100
+    "percent": 100,
+    "id": "1-1-2"
   },
   {
     "name": "1.1.3",
@@ -42,7 +46,8 @@
     "description": "",
     "total": 283,
     "closed": 283,
-    "percent": 100
+    "percent": 100,
+    "id": "1-1-3"
   },
   {
     "name": "1.1.4",
@@ -51,7 +56,8 @@
     "description": "",
     "total": 169,
     "closed": 169,
-    "percent": 100
+    "percent": 100,
+    "id": "1-1-4"
   },
   {
     "name": "1.2",
@@ -60,7 +66,8 @@
     "description": "",
     "total": 73,
     "closed": 73,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2"
   },
   {
     "name": "1.2.1",
@@ -69,7 +76,8 @@
     "description": "",
     "total": 98,
     "closed": 98,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2-1"
   },
   {
     "name": "1.2.2",
@@ -78,7 +86,8 @@
     "description": "",
     "total": 520,
     "closed": 520,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2-2"
   },
   {
     "name": "1.2.3",
@@ -87,7 +96,8 @@
     "description": "",
     "total": 119,
     "closed": 119,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2-3"
   },
   {
     "name": "1.2.4",
@@ -96,7 +106,8 @@
     "description": "",
     "total": 528,
     "closed": 528,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2-4"
   },
   {
     "name": "1.2.5",
@@ -105,7 +116,8 @@
     "description": "",
     "total": 10,
     "closed": 10,
-    "percent": 100
+    "percent": 100,
+    "id": "1-2-5"
   },
   {
     "name": "1.3",
@@ -114,7 +126,8 @@
     "description": "",
     "total": 845,
     "closed": 845,
-    "percent": 100
+    "percent": 100,
+    "id": "1-3"
   },
   {
     "name": "1.3.1",
@@ -123,7 +136,8 @@
     "description": "",
     "total": 106,
     "closed": 106,
-    "percent": 100
+    "percent": 100,
+    "id": "1-3-1"
   },
   {
     "name": "1.3.2",
@@ -132,7 +146,8 @@
     "description": "",
     "total": 272,
     "closed": 272,
-    "percent": 100
+    "percent": 100,
+    "id": "1-3-2"
   },
   {
     "name": "1.4",
@@ -141,7 +156,8 @@
     "description": "",
     "total": 1274,
     "closed": 1274,
-    "percent": 100
+    "percent": 100,
+    "id": "1-4"
   },
   {
     "name": "1.4.1",
@@ -150,7 +166,8 @@
     "description": "",
     "total": 115,
     "closed": 115,
-    "percent": 100
+    "percent": 100,
+    "id": "1-4-1"
   },
   {
     "name": "1.4.2",
@@ -159,7 +176,8 @@
     "description": "",
     "total": 264,
     "closed": 264,
-    "percent": 100
+    "percent": 100,
+    "id": "1-4-2"
   },
   {
     "name": "1.4.3",
@@ -168,7 +186,8 @@
     "description": "",
     "total": 726,
     "closed": 726,
-    "percent": 100
+    "percent": 100,
+    "id": "1-4-3"
   },
   {
     "name": "1.4.4",
@@ -177,7 +196,8 @@
     "description": "Regression fixes for 1.4.3.",
     "total": 64,
     "closed": 64,
-    "percent": 100
+    "percent": 100,
+    "id": "1-4-4"
   },
   {
     "name": "1.5",
@@ -186,7 +206,8 @@
     "description": "1. ~~Modular `$.ajax` rewrite from [https://github.com/jquery/jquery/pull/45 jaubourg]~~\r\\\n2. ~~Deprecate `$.browser`, to be removed at some future date (not 1.5)~~\r\\\n3. ~~Fix `$.data` to avoid key collision with user code~~\r\\\n4. ~~[https://github.com/deadlyicon/jquery/commit/4024e67d0f352e4a095f93456bc8e6da63e10759 Subclassing code]~~\r\\\n5. ~~Deferreds~~",
     "total": 459,
     "closed": 459,
-    "percent": 100
+    "percent": 100,
+    "id": "1-5"
   },
   {
     "name": "1.5.1",
@@ -195,7 +216,8 @@
     "description": "",
     "total": 77,
     "closed": 77,
-    "percent": 100
+    "percent": 100,
+    "id": "1-5-1"
   },
   {
     "name": "1.5.2",
@@ -204,7 +226,8 @@
     "description": "",
     "total": 17,
     "closed": 17,
-    "percent": 100
+    "percent": 100,
+    "id": "1-5-2"
   },
   {
     "name": "1.5.3",
@@ -213,7 +236,8 @@
     "description": "",
     "total": 0,
     "closed": 0,
-    "percent": 100
+    "percent": 100,
+    "id": "1-5-3"
   },
   {
     "name": "1.6",
@@ -222,7 +246,8 @@
     "description": "\r\\\n",
     "total": 294,
     "closed": 294,
-    "percent": 100
+    "percent": 100,
+    "id": "1-6"
   },
   {
     "name": "1.6.1",
@@ -231,7 +256,8 @@
     "description": "",
     "total": 28,
     "closed": 28,
-    "percent": 100
+    "percent": 100,
+    "id": "1-6-1"
   },
   {
     "name": "1.6.2",
@@ -240,7 +266,8 @@
     "description": "",
     "total": 27,
     "closed": 27,
-    "percent": 100
+    "percent": 100,
+    "id": "1-6-2"
   },
   {
     "name": "1.6.3",
@@ -249,7 +276,8 @@
     "description": "",
     "total": 39,
     "closed": 39,
-    "percent": 100
+    "percent": 100,
+    "id": "1-6-3"
   },
   {
     "name": "1.6.4",
@@ -258,7 +286,8 @@
     "description": "",
     "total": 5,
     "closed": 5,
-    "percent": 100
+    "percent": 100,
+    "id": "1-6-4"
   },
   {
     "name": "1.7",
@@ -267,7 +296,8 @@
     "description": "1. Events rewrite (unifying bind/live/delegate, fixing bubbling)\r\\\n2. HTML5 element support",
     "total": 137,
     "closed": 137,
-    "percent": 100
+    "percent": 100,
+    "id": "1-7"
   },
   {
     "name": "1.7.1",
@@ -276,7 +306,8 @@
     "description": "",
     "total": 35,
     "closed": 35,
-    "percent": 100
+    "percent": 100,
+    "id": "1-7-1"
   },
   {
     "name": "1.7.2",
@@ -285,7 +316,8 @@
     "description": "",
     "total": 53,
     "closed": 53,
-    "percent": 100
+    "percent": 100,
+    "id": "1-7-2"
   },
   {
     "name": "1.8",
@@ -294,7 +326,8 @@
     "description": "",
     "total": 166,
     "closed": 166,
-    "percent": 100
+    "percent": 100,
+    "id": "1-8"
   },
   {
     "name": "1.8.1",
@@ -303,7 +336,8 @@
     "description": "",
     "total": 34,
     "closed": 34,
-    "percent": 100
+    "percent": 100,
+    "id": "1-8-1"
   },
   {
     "name": "1.8.2",
@@ -312,7 +346,8 @@
     "description": "",
     "total": 19,
     "closed": 19,
-    "percent": 100
+    "percent": 100,
+    "id": "1-8-2"
   },
   {
     "name": "1.8.3",
@@ -321,7 +356,8 @@
     "description": "",
     "total": 13,
     "closed": 13,
-    "percent": 100
+    "percent": 100,
+    "id": "1-8-3"
   },
   {
     "name": "1.9",
@@ -330,7 +366,8 @@
     "description": "",
     "total": 94,
     "closed": 94,
-    "percent": 100
+    "percent": 100,
+    "id": "1-9"
   },
   {
     "name": "1.9.1",
@@ -339,7 +376,8 @@
     "description": "",
     "total": 21,
     "closed": 21,
-    "percent": 100
+    "percent": 100,
+    "id": "1-9-1"
   },
   {
     "name": "2.0",
@@ -348,7 +386,8 @@
     "description": "",
     "total": 7,
     "closed": 7,
-    "percent": 100
+    "percent": 100,
+    "id": "2-0"
   },
   {
     "name": "1.10",
@@ -357,7 +396,8 @@
     "description": "",
     "total": 18,
     "closed": 18,
-    "percent": 100
+    "percent": 100,
+    "id": "1-10"
   },
   {
     "name": "2.0.1",
@@ -366,7 +406,8 @@
     "description": "",
     "total": 11,
     "closed": 11,
-    "percent": 100
+    "percent": 100,
+    "id": "2-0-1"
   },
   {
     "name": "1.10/2.0",
@@ -375,7 +416,8 @@
     "description": "",
     "total": 16,
     "closed": 16,
-    "percent": 100
+    "percent": 100,
+    "id": "1-10-2-0"
   },
   {
     "name": "1.10.1/2.0.2",
@@ -384,7 +426,8 @@
     "description": "",
     "total": 4,
     "closed": 4,
-    "percent": 100
+    "percent": 100,
+    "id": "1-10-1-2-0-2"
   },
   {
     "name": "1.10.2",
@@ -393,7 +436,8 @@
     "description": "",
     "total": 0,
     "closed": 0,
-    "percent": 100
+    "percent": 100,
+    "id": "1-10-2"
   },
   {
     "name": "1.10.2/2.0.3",
@@ -402,7 +446,8 @@
     "description": "",
     "total": 4,
     "closed": 4,
-    "percent": 100
+    "percent": 100,
+    "id": "1-10-2-2-0-3"
   },
   {
     "name": "2.0.3",
@@ -411,7 +456,8 @@
     "description": "",
     "total": 2,
     "closed": 2,
-    "percent": 100
+    "percent": 100,
+    "id": "2-0-3"
   },
   {
     "name": "1.11",
@@ -420,7 +466,8 @@
     "description": "",
     "total": 7,
     "closed": 7,
-    "percent": 100
+    "percent": 100,
+    "id": "1-11"
   },
   {
     "name": "1.11/2.1",
@@ -429,7 +476,8 @@
     "description": "",
     "total": 52,
     "closed": 52,
-    "percent": 100
+    "percent": 100,
+    "id": "1-11-2-1"
   },
   {
     "name": "2.1",
@@ -438,7 +486,8 @@
     "description": "",
     "total": 9,
     "closed": 9,
-    "percent": 100
+    "percent": 100,
+    "id": "2-1"
   },
   {
     "name": "1.11.1",
@@ -447,7 +496,8 @@
     "description": "",
     "total": 3,
     "closed": 3,
-    "percent": 100
+    "percent": 100,
+    "id": "1-11-1"
   },
   {
     "name": "1.11.1/2.1.1",
@@ -456,7 +506,8 @@
     "description": "",
     "total": 27,
     "closed": 27,
-    "percent": 100
+    "percent": 100,
+    "id": "1-11-1-2-1-1"
   },
   {
     "name": "2.1.1",
@@ -465,7 +516,8 @@
     "description": "",
     "total": 9,
     "closed": 9,
-    "percent": 100
+    "percent": 100,
+    "id": "2-1-1"
   },
   {
     "name": "1.12",
@@ -474,7 +526,8 @@
     "description": "",
     "total": 4,
     "closed": 4,
-    "percent": 100
+    "percent": 100,
+    "id": "1-12"
   },
   {
     "name": "1.12/2.2",
@@ -483,7 +536,8 @@
     "description": "",
     "total": 43,
     "closed": 43,
-    "percent": 100
+    "percent": 100,
+    "id": "1-12-2-2"
   },
   {
     "name": "1.next",
@@ -492,7 +546,8 @@
     "description": "",
     "total": 1510,
     "closed": 1510,
-    "percent": 100
+    "percent": 100,
+    "id": "1-next"
   },
   {
     "name": "1.next/2.next",
@@ -501,7 +556,8 @@
     "description": "",
     "total": 11,
     "closed": 11,
-    "percent": 100
+    "percent": 100,
+    "id": "1-next-2-next"
   },
   {
     "name": "2.2",
@@ -510,7 +566,8 @@
     "description": "",
     "total": 2,
     "closed": 2,
-    "percent": 100
+    "percent": 100,
+    "id": "2-2"
   },
   {
     "name": "2.next",
@@ -519,7 +576,8 @@
     "description": "",
     "total": 9,
     "closed": 9,
-    "percent": 100
+    "percent": 100,
+    "id": "2-next"
   },
   {
     "name": "None",
@@ -528,6 +586,7 @@
     "description": "",
     "total": 4028,
     "closed": 4028,
-    "percent": 100
+    "percent": 100,
+    "id": "none"
   }
 ]

--- a/_includes/milestone-summary.njk
+++ b/_includes/milestone-summary.njk
@@ -1,4 +1,9 @@
 {%- css %}{% include "public/css/milestone-summary.css" %}{% endcss %}
+{%- css %}
+.progress-bar-{{ milestone.id }} {
+  width: {{ milestone.percent }}%;
+}
+{%- endcss %}
 
 <div class="milestone-summary">
   {% if milestone.completed != 0 %}
@@ -11,7 +16,7 @@
 
   <div class="flex-row progress">
     <div class="progress-bar">
-      <div class="progress-bar-fill" style="width: {{ milestone.percent }}%"></div>
+      <div class="progress-bar-fill progress-bar-{{ milestone.id }}"></div>
     </div>
     {{ milestone.percent }}%
   </div>


### PR DESCRIPTION
- Generated IDs for all milestones from the milestone names
- Used the IDs in classes and set the progress bar widths using classes instead. This is to circumvent a CSP error on the milestones page (unsafe-inline).